### PR TITLE
Mark unsafe lifecycle methods to stop deprecation warnings

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -30,8 +30,8 @@ export default class AvatarComponent extends React.Component<Props> {
     getChildContext(): {
         optionContext: OptionContext;
     };
-    componentWillMount(): void;
-    componentWillReceiveProps(nextProps: Props): void;
+    UNSAFE_componentWillMount(): void;
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void;
     render(): JSX.Element;
     private updateOptionContext;
 }
@@ -43,8 +43,8 @@ export declare class Piece extends React.Component<Props> {
     getChildContext(): {
         optionContext: OptionContext;
     };
-    componentWillMount(): void;
-    componentWillReceiveProps(nextProps: Props): void;
+    UNSAFE_componentWillMount(): void;
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void;
     render(): JSX.Element;
     private updateOptionContext;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -30,8 +30,8 @@ export default class AvatarComponent extends React.Component<Props> {
     getChildContext(): {
         optionContext: OptionContext;
     };
-    UNSAFE_componentWillMount(): void;
-    UNSAFE_componentWillReceiveProps(nextProps: Props): void;
+    componentDidMount(): void;
+    componentDidUpdate(): void;
     render(): JSX.Element;
     private updateOptionContext;
 }
@@ -43,8 +43,8 @@ export declare class Piece extends React.Component<Props> {
     getChildContext(): {
         optionContext: OptionContext;
     };
-    UNSAFE_componentWillMount(): void;
-    UNSAFE_componentWillReceiveProps(nextProps: Props): void;
+    componentDidMount(): void;
+    componentDidUpdate(): void;
     render(): JSX.Element;
     private updateOptionContext;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -35,10 +35,10 @@ var AvatarComponent = /** @class */ (function (_super) {
     AvatarComponent.prototype.getChildContext = function () {
         return { optionContext: this.optionContext };
     };
-    AvatarComponent.prototype.componentWillMount = function () {
+    AvatarComponent.prototype.UNSAFE_componentWillMount = function () {
         this.updateOptionContext(this.props);
     };
-    AvatarComponent.prototype.componentWillReceiveProps = function (nextProps) {
+    AvatarComponent.prototype.UNSAFE_componentWillReceiveProps = function (nextProps) {
         this.updateOptionContext(nextProps);
     };
     AvatarComponent.prototype.render = function () {
@@ -73,10 +73,10 @@ var Piece = /** @class */ (function (_super) {
     Piece.prototype.getChildContext = function () {
         return { optionContext: this.optionContext };
     };
-    Piece.prototype.componentWillMount = function () {
+    Piece.prototype.UNSAFE_componentWillMount = function () {
         this.updateOptionContext(this.props);
     };
-    Piece.prototype.componentWillReceiveProps = function (nextProps) {
+    Piece.prototype.UNSAFE_componentWillReceiveProps = function (nextProps) {
         this.updateOptionContext(nextProps);
     };
     Piece.prototype.render = function () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -35,11 +35,11 @@ var AvatarComponent = /** @class */ (function (_super) {
     AvatarComponent.prototype.getChildContext = function () {
         return { optionContext: this.optionContext };
     };
-    AvatarComponent.prototype.UNSAFE_componentWillMount = function () {
+    AvatarComponent.prototype.componentDidMount = function () {
         this.updateOptionContext(this.props);
     };
-    AvatarComponent.prototype.UNSAFE_componentWillReceiveProps = function (nextProps) {
-        this.updateOptionContext(nextProps);
+    AvatarComponent.prototype.componentDidUpdate = function () {
+        this.updateOptionContext(this.props);
     };
     AvatarComponent.prototype.render = function () {
         var _a = this.props, avatarStyle = _a.avatarStyle, style = _a.style;
@@ -73,11 +73,11 @@ var Piece = /** @class */ (function (_super) {
     Piece.prototype.getChildContext = function () {
         return { optionContext: this.optionContext };
     };
-    Piece.prototype.UNSAFE_componentWillMount = function () {
+    Piece.prototype.componentDidMount = function () {
         this.updateOptionContext(this.props);
     };
-    Piece.prototype.UNSAFE_componentWillReceiveProps = function (nextProps) {
-        this.updateOptionContext(nextProps);
+    Piece.prototype.componentDidUpdate = function () {
+        this.updateOptionContext(this.props);
     };
     Piece.prototype.render = function () {
         var _a = this.props, avatarStyle = _a.avatarStyle, style = _a.style, pieceType = _a.pieceType, pieceSize = _a.pieceSize, viewBox = _a.viewBox;

--- a/dist/options/Selector.d.ts
+++ b/dist/options/Selector.d.ts
@@ -11,10 +11,8 @@ export default class Selector extends React.Component<Props> {
         optionContext: PropTypes.Requireable<OptionContext>;
     };
     private get optionContext();
-    UNSAFE_componentWillMount(): void;
-    UNSAFE_componentWillUpdate(nextProps: Props & {
-        children?: React.ReactNode;
-    }): void;
+    componentDidMount(): void;
+    componentDidUpdate(): void;
     componentWillUnmount(): void;
     render(): null;
     private optionContextUpdate;

--- a/dist/options/Selector.d.ts
+++ b/dist/options/Selector.d.ts
@@ -11,8 +11,8 @@ export default class Selector extends React.Component<Props> {
         optionContext: PropTypes.Requireable<OptionContext>;
     };
     private get optionContext();
-    componentWillMount(): void;
-    componentWillUpdate(nextProps: Props & {
+    UNSAFE_componentWillMount(): void;
+    UNSAFE_componentWillUpdate(nextProps: Props & {
         children?: React.ReactNode;
     }): void;
     componentWillUnmount(): void;

--- a/dist/options/Selector.js
+++ b/dist/options/Selector.js
@@ -39,7 +39,7 @@ var Selector = /** @class */ (function (_super) {
         enumerable: true,
         configurable: true
     });
-    Selector.prototype.UNSAFE_componentWillMount = function () {
+    Selector.prototype.componentDidMount = function () {
         var _a = this.props, option = _a.option, defaultOption = _a.defaultOption;
         var optionContext = this.optionContext;
         var defaultValue = (typeof defaultOption === 'string' ?
@@ -52,8 +52,8 @@ var Selector = /** @class */ (function (_super) {
             optionContext.setDefaultValue(option.key, defaultValue);
         }
     };
-    Selector.prototype.UNSAFE_componentWillUpdate = function (nextProps) {
-        this.updateOptionValues(nextProps);
+    Selector.prototype.componentDidUpdate = function () {
+        this.updateOptionValues(this.props);
     };
     Selector.prototype.componentWillUnmount = function () {
         this.optionContext.removeStateChangeListener(this.optionContextUpdate);

--- a/dist/options/Selector.js
+++ b/dist/options/Selector.js
@@ -39,7 +39,7 @@ var Selector = /** @class */ (function (_super) {
         enumerable: true,
         configurable: true
     });
-    Selector.prototype.componentWillMount = function () {
+    Selector.prototype.UNSAFE_componentWillMount = function () {
         var _a = this.props, option = _a.option, defaultOption = _a.defaultOption;
         var optionContext = this.optionContext;
         var defaultValue = (typeof defaultOption === 'string' ?
@@ -52,7 +52,7 @@ var Selector = /** @class */ (function (_super) {
             optionContext.setDefaultValue(option.key, defaultValue);
         }
     };
-    Selector.prototype.componentWillUpdate = function (nextProps) {
+    Selector.prototype.UNSAFE_componentWillUpdate = function (nextProps) {
         this.updateOptionValues(nextProps);
     };
     Selector.prototype.componentWillUnmount = function () {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,11 +39,11 @@ export default class AvatarComponent extends React.Component<Props> {
     return { optionContext: this.optionContext }
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     this.updateOptionContext(this.props)
   }
 
-  componentWillReceiveProps (nextProps: Props) {
+  UNSAFE_componentWillReceiveProps (nextProps: Props) {
     this.updateOptionContext(nextProps)
   }
 
@@ -75,11 +75,11 @@ export class Piece extends React.Component<Props> {
     return { optionContext: this.optionContext }
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     this.updateOptionContext(this.props)
   }
 
-  componentWillReceiveProps (nextProps: Props) {
+  UNSAFE_componentWillReceiveProps (nextProps: Props) {
     this.updateOptionContext(nextProps)
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,18 +33,19 @@ export default class AvatarComponent extends React.Component<Props> {
   static childContextTypes = {
     optionContext: PropTypes.instanceOf(OptionContext)
   }
+
   private optionContext: OptionContext = new OptionContext(allOptions)
 
   getChildContext () {
     return { optionContext: this.optionContext }
   }
 
-  UNSAFE_componentWillMount () {
+  componentDidMount (): void {
     this.updateOptionContext(this.props)
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps: Props) {
-    this.updateOptionContext(nextProps)
+  componentDidUpdate (): void {
+    this.updateOptionContext(this.props)
   }
 
   render () {
@@ -75,12 +76,12 @@ export class Piece extends React.Component<Props> {
     return { optionContext: this.optionContext }
   }
 
-  UNSAFE_componentWillMount () {
+  componentDidMount (): void {
     this.updateOptionContext(this.props)
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps: Props) {
-    this.updateOptionContext(nextProps)
+  componentDidUpdate (): void {
+    this.updateOptionContext(this.props)
   }
 
   render () {

--- a/src/options/Selector.tsx
+++ b/src/options/Selector.tsx
@@ -26,7 +26,7 @@ export default class Selector extends React.Component<Props> {
     return this.context.optionContext
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { option, defaultOption } = this.props
     const { optionContext } = this
     const defaultValue = (
@@ -42,7 +42,7 @@ export default class Selector extends React.Component<Props> {
     }
   }
 
-  componentWillUpdate(nextProps: Props & { children?: React.ReactNode }) {
+  UNSAFE_componentWillUpdate(nextProps: Props & { children?: React.ReactNode }) {
     this.updateOptionValues(nextProps)
   }
 

--- a/src/options/Selector.tsx
+++ b/src/options/Selector.tsx
@@ -26,7 +26,7 @@ export default class Selector extends React.Component<Props> {
     return this.context.optionContext
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount(): void {
     const { option, defaultOption } = this.props
     const { optionContext } = this
     const defaultValue = (
@@ -42,8 +42,8 @@ export default class Selector extends React.Component<Props> {
     }
   }
 
-  UNSAFE_componentWillUpdate(nextProps: Props & { children?: React.ReactNode }) {
-    this.updateOptionValues(nextProps)
+  componentDidUpdate(): void {
+    this.updateOptionValues(this.props)
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
#### What's this PR do?
Prefixes unsafe lifecycle methods with `UNSAFE_`
#### Why is it needed?
To stop the deprecation warnings. To actually address the issue isnt straightforward, this way at least we dont get spammed with the warnings
#### How should this be manually tested?
- In Eureka change the avataaar branch in package.json to this one, delete the avataars folder and run `rake npm:install_assets`
- Run jest and verify there's no deprecation warnings
- Got to the avatar creator and verify it still works as normal